### PR TITLE
deprel now needs uint16 to be able to encode dynamically generated ...

### DIFF
--- a/cmd/search/search.go
+++ b/cmd/search/search.go
@@ -55,7 +55,7 @@ func evalREPLCommand(cmd string) srchCommand {
 
 func main() {
 	limit := flag.Int("limit", 10, "max num. of matching items to show")
-	sortBy := flag.String("sort-by", "tscore", "sorting measure (either tscore or ldice)")
+	sortBy := flag.String("sort-by", "rrf", "sorting measure (either tscore or ldice)")
 	collGroupByPos := flag.Bool("collocate-group-by-pos", false, "if set, then collocates will be split by their PoS")
 	collGroupByDeprel := flag.Bool("collocate-group-by-deprel", false, "if set, then collocates will be split by their Deprel variants")
 	collGroupByTT := flag.Bool("collocate-group-by-tt", false, "if set, then collocates will be split by their text type (registry)")
@@ -165,7 +165,18 @@ func main() {
 				headerFmt := color.New(color.FgGreen).SprintfFunc()
 				columnFmt := color.New(color.FgHiMagenta).SprintfFunc()
 
-				tbl := table.New("registry", "lemma", "lemma props.", "collocate", "collocate props", "T-Score", "Log-Dice", "mutual dist.")
+				tbl := table.New(
+					"registry",
+					"lemma",
+					"lemma props.",
+					"collocate",
+					"collocate props",
+					"T-Score",
+					"Log-Dice",
+					"LMI",
+					"RRF",
+					"mutual dist.",
+				)
 				tbl.
 					WithHeaderFormatter(headerFmt).
 					WithFirstColumnFormatter(columnFmt).

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,13 @@ module github.com/czcorpus/scollector
 go 1.24.1
 
 require (
-	github.com/czcorpus/cnc-gokit v0.14.0
+	github.com/czcorpus/cnc-gokit v0.15.0
 	github.com/dgraph-io/badger/v4 v4.7.0
 	github.com/fatih/color v1.18.0
 	github.com/rodaine/table v1.3.0
 	github.com/rs/zerolog v1.32.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tomachalek/vertigo/v6 v6.1.0
-	google.golang.org/protobuf v1.36.6
 )
 
 require (
@@ -53,6 +52,7 @@ require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
+	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/czcorpus/cnc-gokit v0.14.0 h1:zLFxyfq9hhJFPTLjc0Kze1KakiU+bUa8AHdwRXxTuOQ=
-github.com/czcorpus/cnc-gokit v0.14.0/go.mod h1:4vHbyf+qV8kHHwvWnPhiccMo5pVGY3tnSSRCP0mr2xc=
+github.com/czcorpus/cnc-gokit v0.15.0 h1:d49HXPctNhDOiMO/kfv6BnZkgxAQb8tA21jBA7aFYYw=
+github.com/czcorpus/cnc-gokit v0.15.0/go.mod h1:4vHbyf+qV8kHHwvWnPhiccMo5pVGY3tnSSRCP0mr2xc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/record/input.go
+++ b/record/input.go
@@ -47,7 +47,7 @@ func (otf TokenFreq) String() string {
 		"TokenFreq(lemma: %s, pos: %s, deprel: %s, freq: %d, tt: %x)",
 		otf.Lemma,
 		UDPoSMapping.GetRev(otf.PoS.Byte()),
-		UDDeprelMapping.GetRev(otf.Deprel.Byte()),
+		UDDeprelMapping.GetRev(otf.Deprel.AsUint16()),
 		otf.Freq,
 		otf.TextType,
 	)
@@ -61,9 +61,9 @@ func (otf TokenFreq) HasPoS() bool {
 // e.g. for incremental calculation of lemma's frequency as we process a text source file.
 func (otf TokenFreq) Key() GroupingKey {
 	if otf.PoS.IsValid() {
-		return GroupingKey(fmt.Sprintf("%x|%s|%x|%x", otf.TextType.Byte(), otf.Lemma, otf.PoS.Byte(), otf.Deprel.Byte()))
+		return GroupingKey(fmt.Sprintf("%x|%s|%x|%x", otf.TextType.Byte(), otf.Lemma, otf.PoS.Byte(), otf.Deprel.AsUint16()))
 	}
-	return GroupingKey(fmt.Sprintf("%x|%s|-|%x", otf.TextType.Byte(), otf.Lemma, otf.Deprel.Byte()))
+	return GroupingKey(fmt.Sprintf("%x|%s|-|%x", otf.TextType.Byte(), otf.Lemma, otf.Deprel.AsUint16()))
 }
 
 // LemmaKey generates a key dependent just on the actual lemma (i.e. no PoS etc.).
@@ -104,10 +104,10 @@ func (cf CollocFreq) String() string {
 		"CollocFreq(lemma1: %s, pos1: %s, deprel1: %s, lemma2: %s, pos2: %s, deprel2: %s, freq: %d, tt: %s (%x))",
 		cf.Lemma1,
 		UDPoSMapping.GetRev(cf.PoS1.Byte()),
-		UDDeprelMapping.GetRev(cf.Deprel1.Byte()),
+		UDDeprelMapping.GetRev(cf.Deprel1.AsUint16()),
 		cf.Lemma2,
 		UDPoSMapping.GetRev(cf.PoS2.Byte()),
-		UDDeprelMapping.GetRev(cf.Deprel2.Byte()),
+		UDDeprelMapping.GetRev(cf.Deprel2.AsUint16()),
 		cf.Freq,
 		cf.TextType.Readable,
 		cf.TextType.Raw,
@@ -122,9 +122,9 @@ func (cf *CollocFreq) UpdateFreqAndDist(freq, dist int) {
 
 func (cf CollocFreq) Key() GroupingKey {
 	if cf.PoS1.IsValid() && cf.PoS2.IsValid() {
-		return GroupingKey(fmt.Sprintf("%x|%s|%x|%x|%s|%x|%x", cf.TextType.Byte(), cf.Lemma1, cf.PoS1.Byte(), cf.Deprel1.Byte(), cf.Lemma2, cf.PoS2.Byte(), cf.Deprel2.Byte()))
+		return GroupingKey(fmt.Sprintf("%x|%s|%x|%x|%s|%x|%x", cf.TextType.Byte(), cf.Lemma1, cf.PoS1.Byte(), cf.Deprel1.AsUint16(), cf.Lemma2, cf.PoS2.Byte(), cf.Deprel2.AsUint16()))
 	}
-	return GroupingKey(fmt.Sprintf("%x|%s|%x|%s|%x", cf.TextType.Byte(), cf.Lemma1, cf.Deprel1.Byte(), cf.Lemma2, cf.Deprel2.Byte()))
+	return GroupingKey(fmt.Sprintf("%x|%s|%x|%s|%x", cf.TextType.Byte(), cf.Lemma1, cf.Deprel1.AsUint16(), cf.Lemma2, cf.Deprel2.AsUint16()))
 }
 
 func (cf CollocFreq) Lemma1Key() string {

--- a/record/output.go
+++ b/record/output.go
@@ -25,7 +25,7 @@ import (
 type RawTokenFreq struct {
 	TokenID  uint32
 	PoS      byte
-	Deprel   byte
+	Deprel   uint16
 	Freq     uint32
 	TextType byte
 }
@@ -34,14 +34,13 @@ type RawTokenFreq struct {
 type BinaryKey [8]byte
 
 // GroupingKeyBinary creates a binary key (8 bytes) instead of string key
-// Layout: [TokenID:4][PoS:1][Deprel:1][TextType:1][padding:1]
+// Layout: [TokenID:4][PoS:1][Deprel:2][TextType:1][padding:1]
 func (rtf RawTokenFreq) GroupingKeyBinary() BinaryKey {
 	var key BinaryKey
 	binary.LittleEndian.PutUint32(key[0:4], rtf.TokenID)
 	key[4] = rtf.PoS
-	key[5] = rtf.Deprel
-	key[6] = rtf.TextType
-	// key[7] is padding/unused
+	binary.LittleEndian.PutUint16(key[5:7], rtf.Deprel)
+	key[7] = rtf.TextType
 	return key
 }
 
@@ -70,8 +69,7 @@ func (rtf RawTokenFreq) GroupingKeyOptimized() string {
 	keyBuff.WriteByte(hexChar(rtf.PoS >> 4))
 	keyBuff.WriteByte(hexChar(rtf.PoS & 0xF))
 	keyBuff.WriteByte('|')
-	keyBuff.WriteByte(hexChar(rtf.Deprel >> 4))
-	keyBuff.WriteByte(hexChar(rtf.Deprel & 0xF))
+	keyBuff.WriteString(uitoa(uint64(rtf.Deprel)))
 	keyBuff.WriteByte('|')
 	keyBuff.WriteByte(hexChar(rtf.TextType >> 4))
 	keyBuff.WriteByte(hexChar(rtf.TextType & 0xF))
@@ -83,10 +81,10 @@ func (rtf RawTokenFreq) GroupingKeyOptimized() string {
 type RawCollocFreq struct {
 	Token1ID uint32
 	PoS1     byte
-	Deprel1  byte
+	Deprel1  uint16
 	Token2ID uint32
 	PoS2     byte
-	Deprel2  byte
+	Deprel2  uint16
 	Freq     uint32
 	AVGDist  float64
 	TextType byte
@@ -101,12 +99,12 @@ func (rcf RawCollocFreq) GroupingKeyBinary() CollBinaryKey {
 	var key CollBinaryKey
 	binary.LittleEndian.PutUint32(key[0:4], rcf.Token1ID)
 	key[4] = rcf.PoS1
-	key[5] = rcf.Deprel1
-	binary.LittleEndian.PutUint32(key[6:10], rcf.Token2ID)
-	key[10] = rcf.PoS2
-	key[11] = rcf.Deprel2
-	key[12] = rcf.TextType
-	// key[13:16] are padding/unused
+	binary.LittleEndian.PutUint16(key[5:7], rcf.Deprel1)
+	binary.LittleEndian.PutUint32(key[7:11], rcf.Token2ID)
+	key[11] = rcf.PoS2
+	binary.LittleEndian.PutUint16(key[12:14], rcf.Deprel1)
+	key[14] = rcf.TextType
+	// key[15] is padding/unused
 	return key
 }
 
@@ -115,9 +113,8 @@ func (rcf RawCollocFreq) GroupingKeyLemma1Binary() BinaryKey {
 	var key BinaryKey
 	binary.LittleEndian.PutUint32(key[0:4], rcf.Token1ID)
 	key[4] = rcf.PoS1
-	key[5] = rcf.Deprel1
-	key[6] = rcf.TextType
-	// key[7] is padding/unused
+	binary.LittleEndian.PutUint16(key[5:7], rcf.Deprel1)
+	key[7] = rcf.TextType
 	return key
 }
 
@@ -126,9 +123,8 @@ func (rcf RawCollocFreq) GroupingKeyLemma2Binary() BinaryKey {
 	var key BinaryKey
 	binary.LittleEndian.PutUint32(key[0:4], rcf.Token2ID)
 	key[4] = rcf.PoS2
-	key[5] = rcf.Deprel2
-	key[6] = rcf.TextType
-	// key[7] is padding/unused
+	binary.LittleEndian.PutUint16(key[5:7], rcf.Deprel2)
+	key[7] = rcf.TextType
 	return key
 }
 

--- a/record/types.go
+++ b/record/types.go
@@ -22,14 +22,14 @@ import (
 
 type UDDeprel struct {
 	Readable string
-	Raw      byte
+	Raw      uint16
 }
 
 func (d UDDeprel) IsValid() bool {
-	return d.Raw >= 0x01 && d.Raw <= 0x30
+	return d.Raw >= 0x01
 }
 
-func (d UDDeprel) Byte() byte {
+func (d UDDeprel) AsUint16() uint16 {
 	return d.Raw
 }
 
@@ -42,14 +42,14 @@ func (d UDDeprel) AsUint32() uint32 {
 }
 
 func ImportUDDeprel(v string) UDDeprel {
-	repr, ok := UDDeprelMapping[strings.ToLower(v)]
+	repr, ok := UDDeprelMapping.Get(strings.ToLower(v))
 	if !ok {
 		return UDDeprel{Raw: 0x00, Readable: v}
 	}
-	return UDDeprel{Raw: repr, Readable: v}
+	return UDDeprel{Raw: uint16(repr), Readable: v}
 }
 
-func UDDeprelFromByte(v byte) UDDeprel {
+func UDDeprelFromUint16(v uint16) UDDeprel {
 	readable := UDDeprelMapping.GetRev(v)
 	if readable != "" {
 		return UDDeprel{Raw: v, Readable: readable}
@@ -70,10 +70,6 @@ func (pos UDPoS) Byte() byte {
 
 func (pos UDPoS) String() string {
 	return pos.Readable
-}
-
-func (pos UDPoS) AsUint32() uint32 {
-	return uint32(pos.Raw)
 }
 
 func (pos UDPoS) IsValid() bool {

--- a/record/types_test.go
+++ b/record/types_test.go
@@ -32,8 +32,8 @@ func TestTokenFreq_Key(t *testing.T) {
 			name: "with POS",
 			otf: TokenFreq{
 				Lemma:    "test",
-				PoS:      UDPosFromByte(0x08),    // NOUN
-				Deprel:   UDDeprelFromByte(0x23), // nsubj
+				PoS:      UDPosFromByte(0x08),      // NOUN
+				Deprel:   UDDeprelFromUint16(0x23), // nsubj
 				Freq:     10,
 				TextType: TextType{Raw: 0x01},
 			},
@@ -43,8 +43,8 @@ func TestTokenFreq_Key(t *testing.T) {
 			name: "without POS",
 			otf: TokenFreq{
 				Lemma:    "test",
-				PoS:      UDPosFromByte(0x00),    // no POS
-				Deprel:   UDDeprelFromByte(0x23), // nsubj
+				PoS:      UDPosFromByte(0x00),      // no POS
+				Deprel:   UDDeprelFromUint16(0x23), // nsubj
 				Freq:     10,
 				TextType: TextType{Raw: 0x01},
 			},
@@ -54,8 +54,8 @@ func TestTokenFreq_Key(t *testing.T) {
 			name: "different text type",
 			otf: TokenFreq{
 				Lemma:    "test",
-				PoS:      UDPosFromByte(0x08),    // NOUN
-				Deprel:   UDDeprelFromByte(0x23), // nsubj
+				PoS:      UDPosFromByte(0x08),      // NOUN
+				Deprel:   UDDeprelFromUint16(0x23), // nsubj
 				Freq:     10,
 				TextType: TextType{Raw: 0x02},
 			},
@@ -204,11 +204,11 @@ func TestCollocFreq_Key(t *testing.T) {
 			name: "with both POS",
 			cf: CollocFreq{
 				Lemma1:   "word1",
-				PoS1:     UDPosFromByte(0x08),    // NOUN
-				Deprel1:  UDDeprelFromByte(0x23), // nsubj
+				PoS1:     UDPosFromByte(0x08),      // NOUN
+				Deprel1:  UDDeprelFromUint16(0x23), // nsubj
 				Lemma2:   "word2",
-				PoS2:     UDPosFromByte(0x0f),    // VERB
-				Deprel2:  UDDeprelFromByte(0x27), // obj
+				PoS2:     UDPosFromByte(0x0f),      // VERB
+				Deprel2:  UDDeprelFromUint16(0x27), // obj
 				TextType: TextType{Raw: 0x01},
 			},
 			expected: "1|word1|8|23|word2|f|27",
@@ -218,10 +218,10 @@ func TestCollocFreq_Key(t *testing.T) {
 			cf: CollocFreq{
 				Lemma1:   "word1",
 				PoS1:     UDPosFromByte(0x00),
-				Deprel1:  UDDeprelFromByte(0x23),
+				Deprel1:  UDDeprelFromUint16(0x23),
 				Lemma2:   "word2",
 				PoS2:     UDPosFromByte(0x00),
-				Deprel2:  UDDeprelFromByte(0x27),
+				Deprel2:  UDDeprelFromUint16(0x27),
 				TextType: TextType{Raw: 0x01},
 			},
 			expected: "1|word1|23|word2|27",
@@ -231,10 +231,10 @@ func TestCollocFreq_Key(t *testing.T) {
 			cf: CollocFreq{
 				Lemma1:   "word1",
 				PoS1:     UDPosFromByte(0x08), // NOUN
-				Deprel1:  UDDeprelFromByte(0x23),
+				Deprel1:  UDDeprelFromUint16(0x23),
 				Lemma2:   "word2",
 				PoS2:     UDPosFromByte(0x00), // no POS
-				Deprel2:  UDDeprelFromByte(0x27),
+				Deprel2:  UDDeprelFromUint16(0x27),
 				TextType: TextType{Raw: 0x01},
 			},
 			expected: "1|word1|23|word2|27", // falls back to no-POS format
@@ -251,12 +251,12 @@ func TestCollocFreq_Key(t *testing.T) {
 
 func TestCollocFreq_Key_Uniqueness(t *testing.T) {
 	testCases := []CollocFreq{
-		{Lemma1: "word1", PoS1: UDPosFromByte(0x08), Deprel1: UDDeprelFromByte(0x23), Lemma2: "word2", PoS2: UDPosFromByte(0x0f), Deprel2: UDDeprelFromByte(0x27), TextType: TextType{Raw: 0x01}},
-		{Lemma1: "word1", PoS1: UDPosFromByte(0x0f), Deprel1: UDDeprelFromByte(0x23), Lemma2: "word2", PoS2: UDPosFromByte(0x08), Deprel2: UDDeprelFromByte(0x27), TextType: TextType{Raw: 0x01}}, // swapped POS
-		{Lemma1: "word1", PoS1: UDPosFromByte(0x08), Deprel1: UDDeprelFromByte(0x27), Lemma2: "word2", PoS2: UDPosFromByte(0x0f), Deprel2: UDDeprelFromByte(0x23), TextType: TextType{Raw: 0x01}}, // swapped deprel
-		{Lemma1: "word2", PoS1: UDPosFromByte(0x08), Deprel1: UDDeprelFromByte(0x23), Lemma2: "word1", PoS2: UDPosFromByte(0x0f), Deprel2: UDDeprelFromByte(0x27), TextType: TextType{Raw: 0x01}}, // swapped lemmas
-		{Lemma1: "word1", PoS1: UDPosFromByte(0x08), Deprel1: UDDeprelFromByte(0x23), Lemma2: "word2", PoS2: UDPosFromByte(0x0f), Deprel2: UDDeprelFromByte(0x27), TextType: TextType{Raw: 0x02}}, // different text type
-		{Lemma1: "word1", PoS1: UDPosFromByte(0x00), Deprel1: UDDeprelFromByte(0x23), Lemma2: "word2", PoS2: UDPosFromByte(0x00), Deprel2: UDDeprelFromByte(0x27), TextType: TextType{Raw: 0x01}}, // no POS
+		{Lemma1: "word1", PoS1: UDPosFromByte(0x08), Deprel1: UDDeprelFromUint16(0x23), Lemma2: "word2", PoS2: UDPosFromByte(0x0f), Deprel2: UDDeprelFromUint16(0x27), TextType: TextType{Raw: 0x01}},
+		{Lemma1: "word1", PoS1: UDPosFromByte(0x0f), Deprel1: UDDeprelFromUint16(0x23), Lemma2: "word2", PoS2: UDPosFromByte(0x08), Deprel2: UDDeprelFromUint16(0x27), TextType: TextType{Raw: 0x01}}, // swapped POS
+		{Lemma1: "word1", PoS1: UDPosFromByte(0x08), Deprel1: UDDeprelFromUint16(0x27), Lemma2: "word2", PoS2: UDPosFromByte(0x0f), Deprel2: UDDeprelFromUint16(0x23), TextType: TextType{Raw: 0x01}}, // swapped deprel
+		{Lemma1: "word2", PoS1: UDPosFromByte(0x08), Deprel1: UDDeprelFromUint16(0x23), Lemma2: "word1", PoS2: UDPosFromByte(0x0f), Deprel2: UDDeprelFromUint16(0x27), TextType: TextType{Raw: 0x01}}, // swapped lemmas
+		{Lemma1: "word1", PoS1: UDPosFromByte(0x08), Deprel1: UDDeprelFromUint16(0x23), Lemma2: "word2", PoS2: UDPosFromByte(0x0f), Deprel2: UDDeprelFromUint16(0x27), TextType: TextType{Raw: 0x02}}, // different text type
+		{Lemma1: "word1", PoS1: UDPosFromByte(0x00), Deprel1: UDDeprelFromUint16(0x23), Lemma2: "word2", PoS2: UDPosFromByte(0x00), Deprel2: UDDeprelFromUint16(0x27), TextType: TextType{Raw: 0x01}}, // no POS
 	}
 
 	keys := make(map[GroupingKey]bool)

--- a/record/valmapping.go
+++ b/record/valmapping.go
@@ -16,10 +16,109 @@
 
 package record
 
-type keyValMapping map[string]byte
+type DeprelMapping struct {
+	items    map[string]uint16
+	revCache map[uint16]string
+	maxValue uint16
+}
 
-func (udm keyValMapping) GetRev(val byte) string {
-	for k, v := range udm {
+func (udm *DeprelMapping) Get(key string) (uint16, bool) {
+	v, ok := udm.items[key]
+	return v, ok
+}
+
+func (udm *DeprelMapping) Register(key string) {
+	udm.items[key] = udm.maxValue
+	udm.maxValue++
+}
+
+func (udm *DeprelMapping) GetRev(val uint16) string {
+	v, ok := udm.revCache[val]
+	if ok {
+		return v
+	}
+	for k, v := range udm.items {
+		if v == val {
+			if udm.revCache == nil {
+				udm.revCache = make(map[uint16]string)
+			}
+			udm.revCache[val] = k
+			return k
+		}
+	}
+	return ""
+}
+
+func (udm *DeprelMapping) AsMap() map[string]uint16 {
+	return udm.items
+}
+
+func DeprelMappingFromMap(src map[string]uint16) *DeprelMapping {
+	return &DeprelMapping{
+		items:    src,
+		revCache: map[uint16]string{},
+	}
+}
+
+var UDDeprelMapping = DeprelMapping{
+	maxValue: 0x100,
+	items: map[string]uint16{
+		"acl":          0x0001,
+		"acl:relcl":    0x0002,
+		"advcl":        0x0003,
+		"advmod":       0x0004,
+		"advmod:emph":  0x0005,
+		"amod":         0x0006,
+		"appos":        0x0007,
+		"aux":          0x0008,
+		"aux:pass":     0x0009,
+		"case":         0x000a,
+		"cc":           0x000b,
+		"ccomp":        0x000c,
+		"clf":          0x000d,
+		"compound":     0x000e,
+		"conj":         0x000f,
+		"cop":          0x0010,
+		"csubj":        0x0011,
+		"csubj:pass":   0x0012,
+		"dep":          0x0013,
+		"det":          0x0014,
+		"det:numgov":   0x0015,
+		"det:nummod":   0x0016,
+		"discourse":    0x0017,
+		"dislocated":   0x0018,
+		"expl:pass":    0x0019,
+		"expl:pv":      0x001a,
+		"fixed":        0x001b,
+		"flat":         0x001c,
+		"flat:foreign": 0x001d,
+		"goeswith":     0x001e,
+		"iobj":         0x001f,
+		"list":         0x0020,
+		"mark":         0x0021,
+		"nmod":         0x0022,
+		"nsubj":        0x0023,
+		"nsubj:pass":   0x0024,
+		"nummod":       0x0025,
+		"nummod:gov":   0x0026,
+		"obj":          0x0027,
+		"obl":          0x0028,
+		"obl:arg":      0x0029,
+		"orphan":       0x002a,
+		"parataxis":    0x002b,
+		"punct":        0x002c,
+		"reparandum":   0x002d,
+		"root":         0x002e,
+		"vocative":     0x002f,
+		"xcomp":        0x0030,
+		// dynamically generated values should start with 0x0100
+	},
+}
+
+type posMapping map[string]byte
+
+func (pm posMapping) GetRev(val byte) string {
+	for k, v := range pm {
 		if v == val {
 			return k
 		}
@@ -27,72 +126,33 @@ func (udm keyValMapping) GetRev(val byte) string {
 	return ""
 }
 
-var UDDeprelMapping = keyValMapping{
-	"acl":          0x01,
-	"acl:relcl":    0x02,
-	"advcl":        0x03,
-	"advmod":       0x04,
-	"advmod:emph":  0x05,
-	"amod":         0x06,
-	"appos":        0x07,
-	"aux":          0x08,
-	"aux:pass":     0x09,
-	"case":         0x0a,
-	"cc":           0x0b,
-	"ccomp":        0x0c,
-	"clf":          0x0d,
-	"compound":     0x0e,
-	"conj":         0x0f,
-	"cop":          0x10,
-	"csubj":        0x11,
-	"csubj:pass":   0x12,
-	"dep":          0x13,
-	"det":          0x14,
-	"det:numgov":   0x15,
-	"det:nummod":   0x16,
-	"discourse":    0x17,
-	"dislocated":   0x18,
-	"expl:pass":    0x19,
-	"expl:pv":      0x1a,
-	"fixed":        0x1b,
-	"flat":         0x1c,
-	"flat:foreign": 0x1d,
-	"goeswith":     0x1e,
-	"iobj":         0x1f,
-	"list":         0x20,
-	"mark":         0x21,
-	"nmod":         0x22,
-	"nsubj":        0x23,
-	"nsubj:pass":   0x24,
-	"nummod":       0x25,
-	"nummod:gov":   0x26,
-	"obj":          0x27,
-	"obl":          0x28,
-	"obl:arg":      0x29,
-	"orphan":       0x2a,
-	"parataxis":    0x2b,
-	"punct":        0x2c,
-	"reparandum":   0x2d,
-	"root":         0x2e,
-	"vocative":     0x2f,
-	"xcomp":        0x30,
-}
-
-var UDPoSMapping = keyValMapping{
-	"ADJ":   0x01,
-	"ADP":   0x02,
-	"ADV":   0x03,
-	"AUX":   0x04,
-	"CCONJ": 0x05,
-	"DET":   0x06,
-	"INTJ":  0x07,
-	"NOUN":  0x08,
-	"NUM":   0x09,
-	"PRON":  0x0a,
-	"PROPN": 0x0b,
-	"PUNCT": 0x0c,
-	"SCONJ": 0x0d,
-	"SYM":   0x0e,
-	"VERB":  0x0f,
-	"X":     0x10,
+var UDPoSMapping = posMapping{
+	"ADJ":         0x01,
+	"ADP":         0x02, // (includes prepositions)
+	"ADV":         0x03,
+	"AUX":         0x04,
+	"CCONJ":       0x05,
+	"DET":         0x06,
+	"INTJ":        0x07,
+	"NOUN":        0x08,
+	"NUM":         0x09,
+	"PRON":        0x0a,
+	"PROPN":       0x0b,
+	"PUNCT":       0x0c,
+	"SCONJ":       0x0d,
+	"SYM":         0x0e,
+	"VERB":        0x0f,
+	"X":           0x10,
+	"PART":        0x11,
+	"SCONJ|AUX":   0x12,
+	"PRON|AUX":    0x13,
+	"ADP|PRON":    0x14,
+	"VERB|AUX":    0x15,
+	"PROPN|AUX":   0x16,
+	"NOUN|NOUN":   0x17,
+	"X|AUX":       0x18,
+	"NOUN|AUX":    0x19,
+	"PROPN|NOUN":  0x1a,
+	"PART|AUX":    0x1b,
+	"PROPN|PROPN": 0x1c,
 }

--- a/scoll/calculator.go
+++ b/scoll/calculator.go
@@ -31,22 +31,22 @@ func FromDatabase(db *storage.DB) *Calculator {
 func createPredefinedSearchFilter(srch PredefinedSearch) storage.SearchFilter {
 	switch srch {
 	case ModifiersOf:
-		return func(pos1, deprel1, pos2, deprel2, textType byte) bool {
+		return func(pos1 byte, deprel1 uint16, pos2 byte, deprel2 uint16, textType byte) bool {
 			// TODO implement the logic
 			return false
 		}
 	case NounsModifiedBy:
-		return func(pos1, deprel1, pos2, deprel2, textType byte) bool {
+		return func(pos1 byte, deprel1 uint16, pos2 byte, deprel2 uint16, textType byte) bool {
 			// TODO implement the logic
 			return false
 		}
 	case VerbsObject:
-		return func(pos1, deprel1, pos2, deprel2, textType byte) bool {
+		return func(pos1 byte, deprel1 uint16, pos2 byte, deprel2 uint16, textType byte) bool {
 			// TODO implement the logic
 			return false
 		}
 	case VerbsSubject:
-		return func(pos1, deprel1, pos2, deprel2, textType byte) bool {
+		return func(pos1 byte, deprel1 uint16, pos2 byte, deprel2 uint16, textType byte) bool {
 			// TODO implement the logic
 			return false
 		}

--- a/storage/base.go
+++ b/storage/base.go
@@ -30,9 +30,10 @@ import (
 // DB is a wrapper around badger.DB providing concrete
 // methods for adding/retrieving collocation information.
 type DB struct {
-	bdb       *badger.DB
-	textTypes record.TextTypeMapper
-	Metadata  Metadata
+	bdb           *badger.DB
+	textTypes     record.TextTypeMapper
+	Metadata      Metadata
+	DeprelMapping *record.DeprelMapping
 }
 
 // Close closes the internal Badger database.
@@ -158,6 +159,7 @@ func openDB(path string, loadProfile bool) (*DB, error) {
 				Msg("loaded dataset metadata")
 		}
 		ans.textTypes = prof.TextTypes
+		ans.DeprelMapping = record.DeprelMappingFromMap(ans.Metadata.DeprelMap)
 	}
 
 	return ans, nil

--- a/storage/profiles.go
+++ b/storage/profiles.go
@@ -91,9 +91,10 @@ func FindProfile(name string) Profile {
 }
 
 type Metadata struct {
-	CorpusSize    int64  `json:"corpusSize"`
-	ProfileName   string `json:"profileName"`
-	NumCollFreqs  int    `json:"numCollFreqs"`
-	NumLemmaFreqs int    `json:"numLemmaFreqs"`
-	NumLemmas     int    `json:"numLemmas"`
+	CorpusSize    int64             `json:"corpusSize"`
+	ProfileName   string            `json:"profileName"`
+	NumCollFreqs  int               `json:"numCollFreqs"`
+	NumLemmaFreqs int               `json:"numLemmaFreqs"`
+	NumLemmas     int               `json:"numLemmas"`
+	DeprelMap     map[string]uint16 `json:"deprelMap"`
 }

--- a/storage/rrf.go
+++ b/storage/rrf.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Tomas Machalek <tomas.machalek@gmail.com>
+// Copyright 2025 Department of Linguistics,
+//                Faculty of Arts, Charles University
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"sort"
+)
+
+const (
+	rrfConstantD = 60.0
+)
+
+// SortByRRF orders items using Reciprocal Rank Fusion
+// (https://plg.uwaterloo.ca/%7Egvcormac/cormacksigir09-rrf.pdf)
+func SortByRRF(items []Collocation) {
+	list1 := make([]Collocation, len(items))
+	copy(list1, items)
+	sort.Slice(list1, func(i, j int) bool {
+		return list1[i].LogDice > list1[j].LogDice
+	})
+
+	list2 := make([]Collocation, len(items))
+	copy(list2, items)
+	sort.Slice(list2, func(i, j int) bool {
+		return list2[i].LMI > list2[j].LMI
+	})
+
+	list3 := make([]Collocation, len(items))
+	copy(list3, items)
+	sort.Slice(list3, func(i, j int) bool {
+		return list3[i].TScore > list3[j].TScore
+	})
+
+	scores := make(map[string]float64)
+
+	for i := range len(items) {
+		scores[list1[i].Hash()] += 1.0 / float64((rrfConstantD + i))
+		scores[list2[i].Hash()] += 1.0 / float64((rrfConstantD + i))
+		scores[list3[i].Hash()] += 1.0 / float64((rrfConstantD + i))
+	}
+
+	for i := range len(items) {
+		items[i].RRFScore = scores[items[i].Hash()]
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].RRFScore > items[j].RRFScore
+	})
+
+}

--- a/storage/write.go
+++ b/storage/write.go
@@ -72,15 +72,15 @@ func NewTokenIDSequence() *tokenIDSequence {
 // --------------
 
 func (db *DB) StoreSingleTokenFreqTx(txn *badger.Txn, tokenID uint32, freq record.TokenFreq) error {
-	key := record.TokenFreqKey(tokenID, freq.PoS.Byte(), freq.TextType.Byte(), freq.Deprel.Byte())
+	key := record.TokenFreqKey(tokenID, freq.PoS.Byte(), freq.TextType.Byte(), freq.Deprel.AsUint16())
 	encoded := record.EncodeTokenValue(uint32(freq.Freq))
 	return txn.Set(key, encoded)
 }
 
 func (db *DB) StorePairTokenFreqTx(txn *badger.Txn, token1ID, token2ID uint32, collFreq record.CollocFreq) error {
 	key := record.CollFreqKey(
-		token1ID, collFreq.PoS1.Byte(), collFreq.TextType.Byte(), collFreq.Deprel1.Byte(),
-		token2ID, collFreq.PoS2.Byte(), collFreq.Deprel2.Byte())
+		token1ID, collFreq.PoS1.Byte(), collFreq.TextType.Byte(), collFreq.Deprel1.AsUint16(),
+		token2ID, collFreq.PoS2.Byte(), collFreq.Deprel2.AsUint16())
 	encoded := record.EncodeCollocValue(uint32(collFreq.Freq), collFreq.AVGDist)
 	return txn.Set(key, encoded)
 }

--- a/storage/write_test.go
+++ b/storage/write_test.go
@@ -40,22 +40,22 @@ func TestStoreData(t *testing.T) {
 	singleFreqs := map[record.GroupingKey]record.TokenFreq{
 		"test1": {
 			Lemma:    "word",
-			PoS:      record.UDPosFromByte(0x01),    // ADJ
-			Deprel:   record.UDDeprelFromByte(0x01), // amod
+			PoS:      record.UDPosFromByte(0x01),      // ADJ
+			Deprel:   record.UDDeprelFromUint16(0x01), // amod
 			Freq:     100,
 			TextType: record.TextType{Raw: 0x01, Readable: "test"},
 		},
 		"test2": {
 			Lemma:    "example",
-			PoS:      record.UDPosFromByte(0x02),    // NOUN
-			Deprel:   record.UDDeprelFromByte(0x02), // nsubj
+			PoS:      record.UDPosFromByte(0x02),      // NOUN
+			Deprel:   record.UDDeprelFromUint16(0x02), // nsubj
 			Freq:     50,
 			TextType: record.TextType{Raw: 0x01, Readable: "test"},
 		},
 		"test3": {
 			Lemma:    "run",
-			PoS:      record.UDPosFromByte(0x03),    // VERB
-			Deprel:   record.UDDeprelFromByte(0x03), // root
+			PoS:      record.UDPosFromByte(0x03),      // VERB
+			Deprel:   record.UDDeprelFromUint16(0x03), // root
 			Freq:     75,
 			TextType: record.TextType{Raw: 0x01, Readable: "test"},
 		},
@@ -66,10 +66,10 @@ func TestStoreData(t *testing.T) {
 		"pair1": {
 			Lemma1:   "word",
 			PoS1:     record.UDPosFromByte(0x01),
-			Deprel1:  record.UDDeprelFromByte(0x01),
+			Deprel1:  record.UDDeprelFromUint16(0x01),
 			Lemma2:   "example",
 			PoS2:     record.UDPosFromByte(0x02),
-			Deprel2:  record.UDDeprelFromByte(0x02),
+			Deprel2:  record.UDDeprelFromUint16(0x02),
 			Freq:     25,
 			AVGDist:  1.5,
 			TextType: record.TextType{Raw: 0x01, Readable: "test"},
@@ -77,10 +77,10 @@ func TestStoreData(t *testing.T) {
 		"pair2": {
 			Lemma1:   "example",
 			PoS1:     record.UDPosFromByte(0x02),
-			Deprel1:  record.UDDeprelFromByte(0x02),
+			Deprel1:  record.UDDeprelFromUint16(0x02),
 			Lemma2:   "run",
 			PoS2:     record.UDPosFromByte(0x03),
-			Deprel2:  record.UDDeprelFromByte(0x03),
+			Deprel2:  record.UDDeprelFromUint16(0x03),
 			Freq:     10,
 			AVGDist:  2.0,
 			TextType: record.TextType{Raw: 0x01, Readable: "test"},
@@ -88,10 +88,10 @@ func TestStoreData(t *testing.T) {
 		"pair3": {
 			Lemma1:   "word",
 			PoS1:     record.UDPosFromByte(0x01),
-			Deprel1:  record.UDDeprelFromByte(0x01),
+			Deprel1:  record.UDDeprelFromUint16(0x01),
 			Lemma2:   "run",
 			PoS2:     record.UDPosFromByte(0x03),
-			Deprel2:  record.UDDeprelFromByte(0x03),
+			Deprel2:  record.UDDeprelFromUint16(0x03),
 			Freq:     5,
 			AVGDist:  1.7,
 			TextType: record.TextType{Raw: 0x01, Readable: "test"},
@@ -154,7 +154,7 @@ func TestStoreData(t *testing.T) {
 			// Try to retrieve the pair frequency directly from BadgerDB
 			err := db.bdb.View(func(txn *badger.Txn) error {
 				key := record.CollFreqKey(
-					tokenID1, pairFreq.PoS1.Byte(), pairFreq.TextType.Byte(), pairFreq.Deprel1.Byte(), tokenID2, pairFreq.PoS2.Byte(), pairFreq.Deprel2.Byte())
+					tokenID1, pairFreq.PoS1.Byte(), pairFreq.TextType.Byte(), pairFreq.Deprel1.AsUint16(), tokenID2, pairFreq.PoS2.Byte(), pairFreq.Deprel2.AsUint16())
 				item, err := txn.Get(key)
 				if err != nil {
 					return err
@@ -188,10 +188,10 @@ func TestStoreData(t *testing.T) {
 		lowFreqPair := record.CollocFreq{
 			Lemma1:   "low",
 			PoS1:     record.UDPosFromByte(0x01),
-			Deprel1:  record.UDDeprelFromByte(0x01),
+			Deprel1:  record.UDDeprelFromUint16(0x01),
 			Lemma2:   "freq",
 			PoS2:     record.UDPosFromByte(0x02),
-			Deprel2:  record.UDDeprelFromByte(0x02),
+			Deprel2:  record.UDDeprelFromUint16(0x02),
 			Freq:     2, // Below minPairFreq of 5
 			AVGDist:  10.0,
 			TextType: record.TextType{Raw: 0x01, Readable: "test"},
@@ -201,14 +201,14 @@ func TestStoreData(t *testing.T) {
 			"low": {
 				Lemma:    "low",
 				PoS:      record.UDPosFromByte(0x01),
-				Deprel:   record.UDDeprelFromByte(0x01),
+				Deprel:   record.UDDeprelFromUint16(0x01),
 				Freq:     10,
 				TextType: record.TextType{Raw: 0x01, Readable: "test"},
 			},
 			"freq": {
 				Lemma:    "freq",
 				PoS:      record.UDPosFromByte(0x02),
-				Deprel:   record.UDDeprelFromByte(0x02),
+				Deprel:   record.UDDeprelFromUint16(0x02),
 				Freq:     10,
 				TextType: record.TextType{Raw: 0x01, Readable: "test"},
 			},
@@ -229,7 +229,7 @@ func TestStoreData(t *testing.T) {
 
 		err = db.bdb.View(func(txn *badger.Txn) error {
 			key := record.CollFreqKey(
-				tokenID1, lowFreqPair.PoS1.Byte(), lowFreqPair.TextType.Byte(), lowFreqPair.Deprel1.Byte(), tokenID2, lowFreqPair.PoS2.Byte(), lowFreqPair.Deprel2.Byte())
+				tokenID1, lowFreqPair.PoS1.Byte(), lowFreqPair.TextType.Byte(), lowFreqPair.Deprel1.AsUint16(), tokenID2, lowFreqPair.PoS2.Byte(), lowFreqPair.Deprel2.AsUint16())
 			_, err := txn.Get(key)
 			return err
 		})


### PR DESCRIPTION
... values. Also add LMI measure and Reciprocal Rank Fusion as a universal/default sorting for results.